### PR TITLE
Add missing comma

### DIFF
--- a/src/converter/RenameConverter.mjs
+++ b/src/converter/RenameConverter.mjs
@@ -1041,7 +1041,7 @@ class RenameConverter extends AbstractConverter {
             ["textures/entity/zombie_villager2/levels/gold.png", "textures/entity/zombie_villager2/levels/level_gold.png"],
             ["textures/entity/zombie_villager2/levels/iron.png", "textures/entity/zombie_villager2/levels/level_iron.png"],
             ["textures/entity/zombie_villager2/levels/stone.png", "textures/entity/zombie_villager2/levels/level_stone.png"],
-            ["textures/entity/zombie_villager2/professions/mason.png", "textures/entity/zombie_villager2/professions/stonemason.png"]
+            ["textures/entity/zombie_villager2/professions/mason.png", "textures/entity/zombie_villager2/professions/stonemason.png"],
 
             // Other Changes requested by umfy
             ["textures/block/dirt_path_side.png", "textures/blocks/grass_path_side.png"],


### PR DESCRIPTION
Latest update seems to have broken the deployed version of the site, I think it's this comma because it's always crashing on the conversion right after "textures/entity/zombie_villager2/levels/stone.png" to "textures/entity/zombie_villager2/levels/level_stone.png".

Haven't honestly tested -- couldn't get it to build locally due to some dev env issues that I don't feel like debugging at 4am. But based on the rest of this file, I think this is just a simple missed comma.
